### PR TITLE
Fix input text color in dark mode ios

### DIFF
--- a/ios/Bluezone/Info.plist
+++ b/ios/Bluezone/Info.plist
@@ -102,6 +102,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>


### PR DESCRIPTION
when use dart mode ios, in register screen, phone input text color is white so we can see it